### PR TITLE
Increase the top height on the chart of space usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/components/space-usage/SpaceUsage.js
+++ b/src/components/space-usage/SpaceUsage.js
@@ -3,7 +3,7 @@ import Chart from "assets/img/illustration/chart.svg";
 
 const SpaceUsage = () => {
   return (
-    <div className="flex flex-wrap items-end content-end justify-center mt-6 relative h-32">
+    <div className="flex flex-wrap items-end content-end justify-center mt-6 relative h-40">
       <img src={Chart} alt="Space usage" className="absolute w-full" />
       <h3 className="w-full text-2xl text-center text-gray-800">
         10,5 <small className="text-blue-600">GB</small>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,11 @@
 module.exports = {
-  purge: ['./src/*.js', './src/components/**/*.js'],
-  theme: {
-    extend: {},
-  },
-  variants: {},
-  plugins: [],
+	purge: ['./src/*.js', './src/components/**/*.js'],
+	theme: {
+		extend: {},
+		height: {
+			40: "10rem"
+		}
+	},
+	variants: {},
+	plugins: [],
 };


### PR DESCRIPTION
Hi, thank you for creating this cool template, but I think it would be better if the height of the space usage chart was increased a little. Because it is too close to the username.

**BEFORE**
![before](https://user-images.githubusercontent.com/37969970/89700596-f98c5480-d961-11ea-8e98-c7ad0080cfaf.png)

**AFTER**
![after](https://user-images.githubusercontent.com/37969970/89700597-fdb87200-d961-11ea-8189-22cc4af35698.png)

Thanks